### PR TITLE
require buffer if not available globally

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,10 @@
 
 var toString = Object.prototype.toString
 
+if (typeof Buffer === 'undefined') {
+  global.Buffer = require('buffer').Buffer
+}
+
 var isModern = (
   typeof Buffer.alloc === 'function' &&
   typeof Buffer.allocUnsafe === 'function' &&

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buffer-from",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "repository": "LinusU/buffer-from",
   "files": [


### PR DESCRIPTION
This makes `from-buffer` require `Buffer` and make it available globally if it isn't already available globally. This resolves #9 